### PR TITLE
Update utils.lua

### DIFF
--- a/client/utils.lua
+++ b/client/utils.lua
@@ -71,8 +71,8 @@ function CreateBlip(coords, label)
 		SetBlipSprite(blip, electricbolt) -- This is where the fuel thing will get changed into the electric bolt instead of the pump.
 		SetBlipColour(blip, 5)
 	else
-		SetBlipColour(blip, 4)
 		SetBlipSprite(blip, 361)
+		SetBlipColour(blip, 4)
 	end
 	SetBlipScale(blip, 0.6)
 	SetBlipDisplay(blip, 4)


### PR DESCRIPTION
Lines 74 and 75 switched to allow recoloring of blips. If 'SetBlipColour' comes before 'SetBlipSprite' the colour chosen will not set, stays default white instead.